### PR TITLE
fix: accept object syntax for `to` prop in router mock

### DIFF
--- a/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
@@ -3,7 +3,7 @@ import { defineComponent, useRouter, h } from '#imports'
 export const RouterLink = defineComponent({
   functional: true,
   props: {
-    to: String,
+    to: [String, Object],
     custom: Boolean,
     replace: Boolean,
     // Not implemented


### PR DESCRIPTION
The vue-router mock doesn't accept a named route object.

```
[Vue warn]: Invalid prop: type check failed for prop "to". Expected String with value "[object Object]", got Object  
```