### PR TITLE
fix: correct type of `defineVitestConfig`

### DIFF
--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -89,7 +89,7 @@ export async function getVitestConfigFromNuxt(
   }
 }
 
-export function defineVitestConfig(config: InlineConfig = {}) {
+export function defineVitestConfig(config: VitestConfig = {}) {
   return defineConfig(async () => {
     // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
     if (process.env.__NUXT_VITEST_RESOLVED__) return config


### PR DESCRIPTION
`InlineConfig` is imported twice in [config.ts](https://github.com/danielroe/nuxt-vitest/blob/main/packages/nuxt-vitest/src/config.ts#L2), once from `vitest` and once from `vite`. To prevent a naming conflict, the `InlineConfig` from Vitest is aliased to `VitestConfig`.

However, `defineVitestConfig` [expects](https://github.com/danielroe/nuxt-vitest/blob/main/packages/nuxt-vitest/src/config.ts#L92) Vite's `InlineConfig` as a type, instead of the aliased `VitestConfig`.

This means TypeScript is unhappy when you pass a `test` object to `defineVitestConfig`. 

```
Argument of type '{ test: { clearMocks: boolean; environment: string; globals: boolean; }; }' is not assignable to parameter of type 'InlineConfig'.
  Object literal may only specify known properties, and 'test' does not exist in type 'InlineConfig'.
```

This pull request corrects the config type to `VitestConfig`.