### PR TITLE
fix: mock core nuxt composables

### DIFF
--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -37,7 +37,24 @@ export default defineNuxtModule({
     let components: Component[] = []
 
     nuxt.hook('imports:extend', _ => {
-      imports = _
+      imports = imports.concat(_)
+    })
+    nuxt.hook('imports:sources', _ => {
+      // add core nuxt composables to imports
+      imports = imports.concat(
+        // cast presets to imports
+        _.filter(item => item.from === '#app').flatMap(item =>
+          item.imports.flatMap(name => {
+            return name.toString().startsWith('use')
+              ? {
+                  name: name,
+                  as: name,
+                  from: item.from,
+                }
+              : []
+          })
+        ) as Import[]
+      )
     })
     nuxt.hook('components:extend', _ => {
       components = _

--- a/playground/tests/nuxt/mock-nuxt-composable.spec.ts
+++ b/playground/tests/nuxt/mock-nuxt-composable.spec.ts
@@ -1,0 +1,16 @@
+import { expect, it } from 'vitest'
+import { mockNuxtImport } from 'vitest-environment-nuxt/utils'
+
+mockNuxtImport('useRuntimeConfig', () => {
+  return () => {
+    return {
+      public: { API_ENTRYPOINT: 'http://api.example.com' },
+    }
+  }
+})
+
+it('should mock core nuxt composables', () => {
+  expect(useRuntimeConfig().public?.API_ENTRYPOINT).toMatchInlineSnapshot(
+    '"http://api.example.com"'
+  )
+})


### PR DESCRIPTION
The `mockNuxtImport` doesn't accept a core nuxt composable

```
Cannot find import "useRuntimeConfig" to mock
```

Refs: #29