### PR TITLE
fix: revert type change to `defineVitestConfig`

### DIFF
--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -89,7 +89,7 @@ export async function getVitestConfigFromNuxt(
   }
 }
 
-export function defineVitestConfig(config: VitestConfig = {}) {
+export function defineVitestConfig(config: InlineConfig = {}) {
   return defineConfig(async () => {
     // When Nuxt module calls `startVitest`, we don't need to call `getVitestConfigFromNuxt` again
     if (process.env.__NUXT_VITEST_RESOLVED__) return config


### PR DESCRIPTION
Reverts danielroe/nuxt-vitest#72

Closes https://github.com/danielroe/nuxt-vitest/issues/85

This pull request reverts the earlier pull request, in which I attempted to resolve a typing issue in `defineVitestConfig`. My apologies for causing this regression problem 😢!

I've done some more digging, and I was initially under the impression that the `UserConfig` type did not contain a `test?` property. However, Vitest does extend `UserConfig` with a `test?` property [here](https://github.com/vitest-dev/vitest/blob/c44e5afe135c804ee224bcfa0c5b70ebe47187f4/packages/vitest/src/types/vite.ts#L10).

This did not work in my project however, as my `yarn.lock` contained two `vite` listings due to a versioning conflict between Nuxt's requested Vite version uses and the requested Vite version of the plugins I was using requested. I'm guessing that somehow overrode the module declaration from `Vitest`.

Sorry for any inconvenience this may have caused!