### PR TITLE
fix: mock nuxt module composables

### DIFF
--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -36,25 +36,15 @@ export default defineNuxtModule({
     let imports: Import[] = []
     let components: Component[] = []
 
+    nuxt.hook('imports:context', async ctx => {
+      ctx.getImports().then(_ => {
+        imports = imports.concat(
+          _.filter(item => item.from !== 'vue' && item.name.startsWith('use'))
+        )
+      })
+    })
     nuxt.hook('imports:extend', _ => {
       imports = imports.concat(_)
-    })
-    nuxt.hook('imports:sources', _ => {
-      // add core nuxt composables to imports
-      imports = imports.concat(
-        // cast presets to imports
-        _.filter(item => item.from === '#app').flatMap(item =>
-          item.imports.flatMap(name => {
-            return name.toString().startsWith('use')
-              ? {
-                  name: name,
-                  as: name,
-                  from: item.from,
-                }
-              : []
-          })
-        ) as Import[]
-      )
     })
     nuxt.hook('components:extend', _ => {
       components = _


### PR DESCRIPTION
`imports:sources` doesn't provide nuxt modules auto-imports

Get imports from `imports:context` hook instead of `imports:sources`

Refs: #88