### PR TITLE
fix: pass resolved `runtimeConfig` into nuxt environment

### DIFF
--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -61,6 +61,9 @@ export async function getVitestConfigFromNuxt(
     test: {
       ...options.viteConfig.test,
       dir: options.nuxt.options.rootDir,
+      environmentOptions: {
+        nuxtRuntimeConfig: options.nuxt.options.runtimeConfig,
+      },
       environmentMatchGlobs: [
         ['**/*.nuxt.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}', 'nuxt'],
         ['{test,tests}/nuxt/**.*', 'nuxt'],

--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -62,7 +62,7 @@ export async function getVitestConfigFromNuxt(
       ...options.viteConfig.test,
       dir: options.nuxt.options.rootDir,
       environmentOptions: {
-        ...options.viteConfig.test.environmentOptions,
+        ...options.viteConfig.test?.environmentOptions,
         nuxtRuntimeConfig: options.nuxt.options.runtimeConfig,
       },
       environmentMatchGlobs: [

--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -62,6 +62,7 @@ export async function getVitestConfigFromNuxt(
       ...options.viteConfig.test,
       dir: options.nuxt.options.rootDir,
       environmentOptions: {
+        ...options.viteConfig.test.environmentOptions,
         nuxtRuntimeConfig: options.nuxt.options.runtimeConfig,
       },
       environmentMatchGlobs: [

--- a/packages/vitest-environment-nuxt/src/index.ts
+++ b/packages/vitest-environment-nuxt/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 export default <Environment>{
   name: 'nuxt',
-  async setup() {
+  async setup(_, environmentOptions) {
     const win = new (GlobalWindow || Window)() as any as Window & {
       __app: App
       __registry: Set<string>
@@ -26,6 +26,7 @@ export default <Environment>{
       config: {
         public: {},
         app: { baseURL: '/' },
+        ...environmentOptions?.nuxtRuntimeConfig
       },
       data: {},
       state: {},

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -25,4 +25,9 @@ export default defineNuxtConfig({
       },
     },
   },
+  runtimeConfig: {
+    public: {
+      hello: 'world',
+    },
+  }
 })

--- a/playground/tests/nuxt/config.spec.ts
+++ b/playground/tests/nuxt/config.spec.ts
@@ -1,0 +1,9 @@
+import { it, expect } from 'vitest'
+
+it('should return the runtimeConfig from nuxt.config', () => {
+    const config = useRuntimeConfig();
+    expect(config).toBeTypeOf('object');
+    expect(config?.public).toEqual({
+        hello: 'world'
+    })
+})

--- a/playground/tests/nuxt/config.spec.ts
+++ b/playground/tests/nuxt/config.spec.ts
@@ -1,9 +1,9 @@
 import { it, expect } from 'vitest'
 
 it('should return the runtimeConfig from nuxt.config', () => {
-    const config = useRuntimeConfig();
-    expect(config).toBeTypeOf('object');
-    expect(config?.public).toEqual({
-        hello: 'world'
-    })
+  const config = useRuntimeConfig();
+  expect(config).toBeTypeOf('object');
+  expect(config?.public).toEqual({
+    hello: 'world'
+  })
 })


### PR DESCRIPTION
Resolves danielroe/nuxt-vitest#29