### PR TITLE
chore: run stubbing step as part of dev:prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "private": true,
   "packageManager": "pnpm@7.30.3",
   "scripts": {
-    "build": "pnpm stub && pnpm dev:prepare && pnpm run --filter=./packages/* -r build",
+    "build": "pnpm dev:prepare && pnpm run --filter=./packages/* -r build",
     "stub": "pnpm run --filter=./packages/* -r stub",
-    "dev:prepare": "pnpm nuxi prepare playground",
+    "dev:prepare": "pnpm stub && pnpm nuxi prepare playground",
     "dev": "pnpm run build && pnpm -C playground test:unit",
     "lint": "pnpm lint:all:eslint && pnpm lint:all:prettier",
     "lint:all:eslint": "pnpm lint:eslint --ext .ts,.js,.mjs,.cjs .",


### PR DESCRIPTION
When cloning the repo and following these steps:
![image](https://user-images.githubusercontent.com/463319/227954980-b6cf403a-9fbc-46be-8884-981f19627e7d.png)

We get this error 👇 

![Screenshot 2023-03-27 at 15 32 30](https://user-images.githubusercontent.com/463319/227954718-001e0de8-97cb-4c3b-8543-b244f658010d.png)

It looks like `pnpm stub` is needed before `dev:prepare`.
