### PR TITLE
fix: support `unobserve` method in mocked IntersectionObserver

### DIFF
--- a/packages/vitest-environment-nuxt/src/index.ts
+++ b/packages/vitest-environment-nuxt/src/index.ts
@@ -41,6 +41,7 @@ export default <Environment>{
       win.IntersectionObserver ||
       class IntersectionObserver {
         observe() {}
+        unobserve() {}
       }
 
     const h3App = createApp()


### PR DESCRIPTION
While using testing libraries such as: 

https://testing-library.com/docs/vue-testing-library/intro/

And trying to get full [coverage](https://vitest.dev/guide/coverage.html) of the template while mounting a simple component using child components from:

https://headlessui.com/vue/menu

I encountered missing coverage in my testing; after trying different things, it seems some events are not properly propagated by vue-testing-library fireEvent method, so I tried to use an extension they developed for this situation:

https://github.com/testing-library/user-event

When executing my code using the library mentioned I was able to get full coverage, but I saw an error in my console

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: observer.unobserve is not a function
 ❯ node_modules/nuxt/dist/app/components/nuxt-link.js:278:16
    277|   const _observer = nuxtApp._observer = {
    278|     observe
    279|   };
       |    ^
    280|   return _observer;
    281| }
```

After debugging the error, it seems it only required the unobserve method to be present.

Tested this theory by locally updating /node_modules/vitest-environment-nuxt/dist/index.mjs

After applying the changes locally the error was no longer visible, and the testing and coverage finished successfully.

Note: I believe this is my first PR :) 
