### PR TITLE
docs: add example `@nuxt/test-utils` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,39 @@ mockComponent('MyComponent', async () => {
 })
 ```
 
+### Conflict with @nuxt/test-utils
+
+`nuxt-vitest` and `@nuxt/test-utils` need to run in different testing environments and so can't be used in the same file.
+
+If you would like to use `@nuxt/test-utils` to conduct end-to-end tests on your Nuxt app, you can split your tests into separate files. You then either specify a test environment per-file with the special `// @vitest-environment nuxt` comment, or name your `nuxt-vitest` files with the `.nuxt.spec.ts` extension.
+
+`app.nuxt.spec.js`
+
+```ts
+import { mockNuxtImport } from "nuxt-vitest/utils";
+
+mockNuxtImport('useStorage', () => {
+  return () => {
+    return { value: 'mocked storage' }
+  }
+})
+
+```
+
+`app.e2e.spec.js`
+
+```ts
+import { setup, $fetch } from '@nuxt/test-utils';
+
+await setup({
+  setupTimeout: 10000,
+});
+
+// ...
+```
+
+
+
 ## 💻 Development
 
 - Clone this repository


### PR DESCRIPTION
In order to inform early about incompatabilities and avoid [invalid bug reports](https://github.com/nuxt/nuxt/issues/20651#event-9164321110) we introduce a section specifically targeting the conflict with `@nuxt/test-utils` 

