### PR TITLE
feat: allow passing mount options in `mountSuspended`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 *.log*
 dist
+
+.idea

--- a/packages/vitest-environment-nuxt/package.json
+++ b/packages/vitest-environment-nuxt/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.2.0",
     "@vue/test-utils": "^2.3.2",
+    "defu": "^6.1.2",
     "estree-walker": "^3.0.3",
     "h3": "^1.6.5",
     "happy-dom": "^9.10.9",

--- a/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
@@ -3,7 +3,7 @@ import { defineComponent, useRouter, h } from '#imports'
 export const RouterLink = defineComponent({
   functional: true,
   props: {
-    to: String,
+    to: [String, Object],
     custom: Boolean,
     replace: Boolean,
     // Not implemented

--- a/packages/vitest-environment-nuxt/src/runtime/mount.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/mount.ts
@@ -17,7 +17,7 @@ interface Options extends MountSuspendedOptions, MountingOptions<any, any> {}
 
 export async function mountSuspended<
   T extends DefineComponent<any, any, any, any>
-> (component: T, options?: Options) {
+>(component: T, options?: Options) {
   const {
     props = {},
     attrs = {},
@@ -39,7 +39,7 @@ export async function mountSuspended<
             {
               default: () =>
                 h({
-                  async setup () {
+                  async setup() {
                     const router = useRouter()
                     await router.replace(route)
                     return () => h(component, { ...props, ...attrs }, slots)

--- a/packages/vitest-environment-nuxt/src/runtime/mount.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/mount.ts
@@ -9,15 +9,13 @@ import { RouterLink } from './components/RouterLink'
 import NuxtRoot from '#build/root-component.mjs'
 import { useRouter } from '#imports'
 
-interface MountSuspendedOptions {
+interface MountSuspendedOptions extends MountingOptions<any, any> {
   route?: RouteLocationRaw
 }
 
-interface Options extends MountSuspendedOptions, MountingOptions<any, any> {}
-
 export async function mountSuspended<
   T extends DefineComponent<any, any, any, any>
->(component: T, options?: Options) {
+> (component: T, options?: MountSuspendedOptions) {
   const {
     props = {},
     attrs = {},

--- a/packages/vitest-environment-nuxt/src/runtime/mount.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/mount.ts
@@ -1,4 +1,4 @@
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount, VueWrapper, MountingOptions } from '@vue/test-utils'
 import { h, DefineComponent, Suspense, nextTick } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
@@ -12,9 +12,11 @@ interface MountSuspendedOptions {
   route?: RouteLocationRaw
 }
 
+interface Options extends MountSuspendedOptions, MountingOptions<any, any> {}
+
 export async function mountSuspended<
   T extends DefineComponent<any, any, any, any>
->(component: T, options?: MountSuspendedOptions) {
+>(component: T, options?: Options) {
   // @ts-expect-error untyped global __unctx__
   const vueApp = globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
   return new Promise<VueWrapper<InstanceType<T>>>(resolve => {
@@ -31,19 +33,27 @@ export async function mountSuspended<
                   async setup() {
                     const router = useRouter()
                     await router.replace(options?.route || '/')
-                    return () => h(component)
+                    return () => h(
+                      component,
+                      { ...options?.props, ...options?.attrs },
+                      { ...options?.slots }
+                    )
                   },
                 }),
             }
           ),
       },
       {
+        ...options,
         global: {
+          ...options?.global,
           config: {
+            ...options?.global?.config,
             globalProperties: vueApp.config.globalProperties,
           },
           provide: vueApp._context.provides,
           components: {
+            ...options?.global?.components,
             RouterLink,
           },
         },

--- a/packages/vitest-environment-nuxt/src/runtime/mount.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/mount.ts
@@ -1,5 +1,6 @@
 import { mount, VueWrapper, MountingOptions } from '@vue/test-utils'
 import { h, DefineComponent, Suspense, nextTick } from 'vue'
+import { defu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
 
 import { RouterLink } from './components/RouterLink'
@@ -16,7 +17,15 @@ interface Options extends MountSuspendedOptions, MountingOptions<any, any> {}
 
 export async function mountSuspended<
   T extends DefineComponent<any, any, any, any>
->(component: T, options?: Options) {
+> (component: T, options?: Options) {
+  const {
+    props = {},
+    attrs = {},
+    slots = {},
+    route = '/',
+    ..._options
+  } = options || {}
+
   // @ts-expect-error untyped global __unctx__
   const vueApp = globalThis.__unctx__.get('nuxt-app').tryUse().vueApp
   return new Promise<VueWrapper<InstanceType<T>>>(resolve => {
@@ -30,34 +39,24 @@ export async function mountSuspended<
             {
               default: () =>
                 h({
-                  async setup() {
+                  async setup () {
                     const router = useRouter()
-                    await router.replace(options?.route || '/')
-                    return () => h(
-                      component,
-                      { ...options?.props, ...options?.attrs },
-                      { ...options?.slots }
-                    )
+                    await router.replace(route)
+                    return () => h(component, { ...props, ...attrs }, slots)
                   },
                 }),
             }
           ),
       },
-      {
-        ...options,
+      defu(_options, {
         global: {
-          ...options?.global,
           config: {
-            ...options?.global?.config,
             globalProperties: vueApp.config.globalProperties,
           },
           provide: vueApp._context.provides,
-          components: {
-            ...options?.global?.components,
-            RouterLink,
-          },
+          components: { RouterLink },
         },
-      }
+      })
     )
   })
 }

--- a/playground/components/OptionsComponent.vue
+++ b/playground/components/OptionsComponent.vue
@@ -7,12 +7,8 @@
 
 <script setup lang="ts">
 withDefaults(
-    defineProps<{
-        title?: string
-    }>(),
-    {
-        title: 'The original',
-    }
+  defineProps<{ title?: string }>(),
+  { title: 'The original' }
 )
 
 await new Promise(resolve => setTimeout(resolve, 1))

--- a/playground/components/OptionsComponent.vue
+++ b/playground/components/OptionsComponent.vue
@@ -1,0 +1,19 @@
+<template>
+  <h2>{{ title }}</h2>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+    defineProps<{
+        title?: string
+    }>(),
+    {
+        title: 'The original',
+    }
+)
+
+await new Promise(resolve => setTimeout(resolve, 1))
+</script>

--- a/playground/tests/nuxt/index.spec.ts
+++ b/playground/tests/nuxt/index.spec.ts
@@ -4,6 +4,7 @@ import { mountSuspended, registerEndpoint } from 'vitest-environment-nuxt/utils'
 
 import App from '~/app.vue'
 import FetchComponent from '~/components/FetchComponent.vue'
+import OptionsComponent from "~/components/OptionsComponent.vue";
 
 describe('client-side nuxt features', () => {
   it('can use core nuxt composables within test file', () => {
@@ -48,6 +49,35 @@ describe('test utils', () => {
       <div>Index page</div>
       <a href=\\"/test\\"> Test link </a>"
     `)
+  })
+
+  it('should render default props within nuxt suspense', async () => {
+    const component = await mountSuspended(OptionsComponent)
+    expect(component.find('h2').html()).toMatchInlineSnapshot(
+        '"<h2>The original</h2>"'
+    )
+  })
+
+  it('should render passed props within nuxt suspense', async () => {
+    const component = await mountSuspended(OptionsComponent, {
+      props: {
+        title: 'title from mount suspense props',
+      },
+    })
+    expect(component.find('h2').html()).toMatchInlineSnapshot(
+        '"<h2>title from mount suspense props</h2>"'
+    )
+  })
+
+  it('can pass slots to mounted components within nuxt suspense', async () => {
+    const component = await mountSuspended(OptionsComponent, {
+      slots: {
+        default: 'slot from mount suspense',
+      },
+    })
+    expect(component.find('div').html()).toMatchInlineSnapshot(
+        '"<div>slot from mount suspense</div>"'
+    )
   })
 
   it('can mock fetch requests', async () => {

--- a/playground/tests/nuxt/index.spec.ts
+++ b/playground/tests/nuxt/index.spec.ts
@@ -4,7 +4,7 @@ import { mountSuspended, registerEndpoint } from 'vitest-environment-nuxt/utils'
 
 import App from '~/app.vue'
 import FetchComponent from '~/components/FetchComponent.vue'
-import OptionsComponent from "~/components/OptionsComponent.vue";
+import OptionsComponent from '~/components/OptionsComponent.vue'
 
 describe('client-side nuxt features', () => {
   it('can use core nuxt composables within test file', () => {
@@ -54,7 +54,7 @@ describe('test utils', () => {
   it('should render default props within nuxt suspense', async () => {
     const component = await mountSuspended(OptionsComponent)
     expect(component.find('h2').html()).toMatchInlineSnapshot(
-        '"<h2>The original</h2>"'
+      '"<h2>The original</h2>"'
     )
   })
 
@@ -65,18 +65,18 @@ describe('test utils', () => {
       },
     })
     expect(component.find('h2').html()).toMatchInlineSnapshot(
-        '"<h2>title from mount suspense props</h2>"'
+      '"<h2>title from mount suspense props</h2>"'
     )
   })
 
   it('can pass slots to mounted components within nuxt suspense', async () => {
     const component = await mountSuspended(OptionsComponent, {
       slots: {
-        default: 'slot from mount suspense',
+        default: () => 'slot from mount suspense',
       },
     })
     expect(component.find('div').html()).toMatchInlineSnapshot(
-        '"<div>slot from mount suspense</div>"'
+      '"<div>slot from mount suspense</div>"'
     )
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 1.2.1
       vitest:
         specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.10.9)
+        version: 0.30.1(@vitest/ui@0.30.0)
       vue:
         specifier: 3.2.47
         version: 3.2.47
@@ -111,6 +111,9 @@ importers:
       '@vue/test-utils':
         specifier: ^2.3.2
         version: 2.3.2(vue@3.2.47)
+      defu:
+        specifier: ^6.1.2
+        version: 6.1.2
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
@@ -152,7 +155,7 @@ importers:
         version: link:../packages/nuxt-vitest
       vitest:
         specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.10.9)
+        version: 0.30.1(@vitest/ui@0.30.0)
       vitest-environment-nuxt:
         specifier: workspace:*
         version: link:../packages/vitest-environment-nuxt
@@ -1808,7 +1811,7 @@ packages:
       c8: 7.13.0
       picocolors: 1.0.0
       std-env: 3.3.3
-      vitest: 0.30.1(happy-dom@9.10.9)
+      vitest: 0.30.1(@vitest/ui@0.30.0)
     dev: true
 
   /@vitest/expect@0.30.1:
@@ -1848,7 +1851,6 @@ packages:
       pathe: 1.1.0
       picocolors: 1.0.0
       sirv: 2.0.2
-    dev: false
 
   /@vitest/utils@0.30.0:
     resolution: {integrity: sha512-qFZgoOKQ+rJV9xG4BBxgOSilnLQ2gkfG4I+z1wBuuQ3AD33zQrnB88kMFfzsot1E1AbF3dNK1e4CU7q3ojahRA==}
@@ -1856,7 +1858,6 @@ packages:
       concordance: 5.0.4
       loupe: 2.3.6
       pretty-format: 27.5.1
-    dev: false
 
   /@vitest/utils@0.30.1:
     resolution: {integrity: sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==}
@@ -3108,6 +3109,7 @@ packages:
 
   /css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: false
 
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3983,7 +3985,6 @@ packages:
 
   /fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
-    dev: false
 
   /figures@5.0.0:
     resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
@@ -4513,6 +4514,7 @@ packages:
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
+    dev: false
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -4577,6 +4579,7 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: false
 
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -9044,7 +9047,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: false
 
   /vitest@0.30.1(happy-dom@9.10.9):
     resolution: {integrity: sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==}
@@ -9111,6 +9113,7 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: false
 
   /vm2@3.9.14:
     resolution: {integrity: sha512-HgvPHYHeQy8+QhzlFryvSteA4uQLBCOub02mgqdR+0bN/akRZ48TGB1v0aCv7ksyc0HXx16AZtMHKS38alc6TA==}
@@ -9248,6 +9251,7 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+    dev: false
 
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -9265,10 +9269,12 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
+    dev: false
 
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}


### PR DESCRIPTION
This PR adds mount support for vue-test-utils mount function. (See https://github.com/danielroe/nuxt-vitest/issues/87)
Mostly of the work has been done by @ghazialhouwari. (https://github.com/ghazialhouwari/nuxt-vitest)

Tests haven't been tested cause of the following issue:
```
 Cannot read properties of null (reading 'scope')
```
Looks like it's a SSR issue and the component is missing an active currentInstance, see https://github.com/vuejs/core/issues/7402 for more information.

See screenshot for Vue warnings:
![Schermafbeelding 2023-05-07 om 14 20 46](https://user-images.githubusercontent.com/7252657/236677240-047905af-68da-4b3f-8c84-2bb7ccfec9c2.png)