### PR TITLE
docs: add directions on opting out from global environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ export default defineVitestConfig({
 })
 ```
 
-And opt-out [to the default environment](https://vitest.dev/guide/environment.html#test-environment) per test file if the nuxt environment isn't needed.
+If you have set `environment: 'nuxt'` by default, you can then opt-out [of the default environment](https://vitest.dev/guide/environment.html#test-environment) per test file as needed.
 
 ```js
 // @vitest-environment node
@@ -86,8 +86,6 @@ test('my test', () => {
   // ... test without Nuxt environment!
 })
 ```
-
-
 ## 👉 Important notes
 
 When you run your tests within the Nuxt environment, they will be running in a [`happy-dom`](https://github.com/capricorn86/happy-dom) environment. Before your tests run, a global Nuxt app will be initialised (including, for example, running any plugins or code you've defined in your `app.vue`).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ export default defineVitestConfig({
 })
 ```
 
+And opt-out [to the default environment](https://vitest.dev/guide/environment.html#test-environment) per test file if the nuxt environment isn't needed.
+
+```js
+// @vitest-environment node
+import { test } from 'vitest'
+
+test('my test', () => {
+  // ... test without Nuxt environment!
+})
+```
+
+
 ## 👉 Important notes
 
 When you run your tests within the Nuxt environment, they will be running in a [`happy-dom`](https://github.com/capricorn86/happy-dom) environment. Before your tests run, a global Nuxt app will be initialised (including, for example, running any plugins or code you've defined in your `app.vue`).

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ test('my test', () => {
   // ... test without Nuxt environment!
 })
 ```
+
 ## 👉 Important notes
 
 When you run your tests within the Nuxt environment, they will be running in a [`happy-dom`](https://github.com/capricorn86/happy-dom) environment. Before your tests run, a global Nuxt app will be initialised (including, for example, running any plugins or code you've defined in your `app.vue`).


### PR DESCRIPTION
The Setup Sections explains how to opt-in or set the nuxt-environment globally. 

There is good chance global nuxt environment for existing project causes error in some spec files so this introduces a follow up hint how to opt-out of the global env per test file. 

stackblitz: https://stackblitz.com/edit/nuxt-vitest-c8mrz7?file=vitest.config.mjs,test%2Fapp.e2e.spec.ts,tsconfig.json