### PR TITLE
docs: correct import style for composable mock file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ export default useStorageMock
 ```
 
 ```ts
-import { useStorageMock } from './useStorageMock'
+import useStorageMock from './useStorageMock'
 import { mockNuxtImport } from 'nuxt-vitest/utils'
 
 mockNuxtImport('useStorage', () => {


### PR DESCRIPTION
because the file example does not provide a named export 

```
// useStorageMock.ts
let useStorageMock = vi.fn(() => {
  return { value: 'mocked storage' }
})
export default useStorageMock
```