### PR TITLE
docs: update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 1. First install `nuxt-vitest`:
 
 ```bash
-pnpm add -D nuxt-vitest
+pnpm add nuxt-vitest
 
 # or
-yarn add --dev nuxt-vitest
-npm i -D nuxt-vitest
+yarn add nuxt-vitest
+npm i nuxt-vitest
 ```
 
 2. Add `nuxt-vitest` to your `nuxt.config.js`:


### PR DESCRIPTION
Because `nuxt-vitest` is included as a module in the `nuxt.config.{ts,js}`, the package is needed as a production dependency for the Nuxt build to succeed.

Is there a way to add `nuxt-vitest` for a production Nuxt app, while keeping it as a devDependency?