### PR TITLE
docs: install `vitest` in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 1. First install `nuxt-vitest`:
 
 ```bash
-pnpm add -D nuxt-vitest
+pnpm add -D nuxt-vitest vitest
 
 # or
-yarn add --dev nuxt-vitest
-npm i -D nuxt-vitest
+yarn add --dev nuxt-vitest vitest
+npm i -D nuxt-vitest vitest
 ```
 
 2. Add `nuxt-vitest` to your `nuxt.config.js`:


### PR DESCRIPTION
The document missed the vitest dependency while installing, and the nuxt-vitest module dosen't expose vitest to user application by default, missing the vitest dependency may misleading users that they can use vitest directy from nuxt-vitest.