### PR TITLE
fix: properly set default route

### DIFF
--- a/packages/vitest-environment-nuxt/src/index.ts
+++ b/packages/vitest-environment-nuxt/src/index.ts
@@ -12,7 +12,10 @@ import {
 export default <Environment>{
   name: 'nuxt',
   async setup(_, environmentOptions) {
-    const win = new (GlobalWindow || Window)() as any as Window & {
+    const win = new (GlobalWindow || Window)({
+      // Happy-dom defaults to `about:blank`
+      url: 'http://localhost:3000',
+    }) as any as Window & {
       __app: App
       __registry: Set<string>
       __NUXT__: any

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,8 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
+  app: {
+    rootId: 'nuxt-test',
+  },
   modules: [
     '../packages/nuxt-vitest/src/module',
     '@nuxt/devtools',

--- a/playground/tests/nuxt/index.spec.ts
+++ b/playground/tests/nuxt/index.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import { mountSuspended, registerEndpoint } from 'vitest-environment-nuxt/utils'
 
+import { watch } from 'vue'
 import App from '~/app.vue'
 import FetchComponent from '~/components/FetchComponent.vue'
 import OptionsComponent from '~/components/OptionsComponent.vue'
@@ -29,16 +30,24 @@ describe('client-side nuxt features', () => {
   it('defaults to index page', async () => {
     expect(useRoute().matched[0].meta).toMatchInlineSnapshot(`
       {
-        "slug": "foo",
+        "value": "set in index",
       }
     `)
     // TODO: should it be possible to push to other routes?
   })
 
-  it('allows pushing to other pages', async () => {
-    await useRouter().push('/something')
-    expect(useRoute().fullPath).toMatchInlineSnapshot('"/something"')
-  })
+  it('allows pushing to other pages', async () =>
+    new Promise<void>(done => {
+      useRouter()
+        .push('/something')
+        .then(() => {
+          const stop = watch(useRoute(), () => {
+            expect(useRoute().fullPath).toMatchInlineSnapshot('"/something"')
+            stop()
+            done()
+          })
+        })
+    }))
 })
 
 describe('test utils', () => {


### PR DESCRIPTION
This PR relates to #121 and fixes some underlying test issues uncovered when attempting to fix the failing tests in that PR.

---

By default `happy-dom` will have the URL `about:blank`. In the tests it seems we were assuming we would immediately end up on an index page when in fact we were not due to this behavior of `happy-dom`.

This change properly sets the default URL to `http://localhost:3000` which is the same as Vitest sets for JSDOM.

There were two tests that started failing for this change:

1. "defaults to index page" 
This test previously was ending up on the "slug" page, since the URL was matching "about:blank" to this. This snapshot was updated since it now correctly goes to the index page.

2. "allows pushing to other pages"
The `useRoute()` in this test can no longer be called sync. We need to wait for the reactive route variable to update. Assuming this is due to some previous quirk when vue-router encountered "about:blank".