### PR TITLE
feat(vitest-environment-nuxt): allow mocking imports within setup files

### DIFF
--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -1,7 +1,7 @@
 import type { Import, Unimport } from 'unimport'
 import { addVitePlugin, defineNuxtModule } from '@nuxt/kit'
 import { walk } from 'estree-walker'
-import type { CallExpression, ImportDeclaration } from 'estree'
+import type { CallExpression } from 'estree'
 import { AcornNode } from 'rollup'
 import MagicString from 'magic-string'
 import { Component } from '@nuxt/schema'
@@ -107,8 +107,8 @@ export default defineNuxtModule({
           const s = new MagicString(code)
           const mocksImport: MockImportInfo[] = []
           const mocksComponent: MockComponentInfo[] = []
-          const importList: ImportDeclaration[] = []
           const importPathsList: Set<string> = new Set()
+
           walk(ast as any, {
             enter: (node, parent) => {
               // find existing vi import
@@ -129,8 +129,6 @@ export default defineNuxtModule({
                   }
                   return
                 }
-
-                importList.push(node)
               }
 
               if (node.type !== 'CallExpression') return
@@ -278,7 +276,7 @@ export default defineNuxtModule({
           // if not, the module won't be mocked
           if(shouldPrependMockHoist) {
             importPathsList.forEach((p) => { 
-              s.append( `\n import ${JSON.stringify(p)};\n`)
+              s.append( `\n import ${JSON.stringify(p)};`)
             })
           }
 

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -265,7 +265,7 @@ export default defineNuxtModule({
 
 
           if (shouldPrependMockHoist) {
-            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, {})});\n`)
+            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, { _nuxtVitest: true })});\n`)
           }
 
           if (!hasViImport) s.prepend(`import {vi} from "vitest";\n`)

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -265,7 +265,7 @@ export default defineNuxtModule({
 
 
           if (shouldPrependMockHoist) {
-            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, { _nuxtVitest: true })});\n`)
+            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, {})});\n`)
           }
 
           if (!hasViImport) s.prepend(`import {vi} from "vitest";\n`)

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -85,7 +85,7 @@ export default defineNuxtModule({
       transform: {
         handler(code, id) {
           const isFirstSetupFile = normalize(id) === resolvedFirstSetupFile
-          const shouldPrependMockHoist = isFirstSetupFile
+          const shouldPrependMockHoist = resolvedFirstSetupFile ? isFirstSetupFile : true
 
           if (!HELPERS_NAME.some(n => code.includes(n)) && isFirstSetupFile) return
           if (id.includes('/node_modules/')) return
@@ -232,7 +232,7 @@ export default defineNuxtModule({
                     `vi.mock(${JSON.stringify(
                       from
                     )}, async (importOriginal) => {`,
-                    `  const mocks = global.${HELPER_MOCK_HOIST} || {}`,
+                    `  const mocks = global.${HELPER_MOCK_HOIST}`,
                     `  if (!mocks[${JSON.stringify(from)}]) { mocks[${JSON.stringify(from)}] = { ...await import(${JSON.stringify(from)}) } }`,
                   ]
                   for (const mock of mocks) {
@@ -281,7 +281,7 @@ export default defineNuxtModule({
               s.append( `\n import ${JSON.stringify(p)};\n`)
             })
           }
-         
+
           return {
             code: s.toString(),
             map: s.generateMap(),

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -87,7 +87,7 @@ export default defineNuxtModule({
           const isFirstSetupFile = normalize(id) === resolvedFirstSetupFile
           const shouldPrependMockHoist = resolvedFirstSetupFile ? isFirstSetupFile : true
 
-          if (!HELPERS_NAME.some(n => code.includes(n)) && isFirstSetupFile) return
+          if (!HELPERS_NAME.some(n => code.includes(n))) return
           if (id.includes('/node_modules/')) return
 
           let ast: AcornNode

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -233,7 +233,7 @@ export default defineNuxtModule({
                       from
                     )}, async (importOriginal) => {`,
                     `  const mocks = global.${HELPER_MOCK_HOIST}`,
-                    `  if (!mocks[${JSON.stringify(from)}]) { mocks[${JSON.stringify(from)}] = { ...await import(${JSON.stringify(from)}) } }`,
+                    `  if (!mocks[${JSON.stringify(from)}]) { mocks[${JSON.stringify(from)}] = { ...await importOriginal(${JSON.stringify(from)}) } }`,
                   ]
                   for (const mock of mocks) {
                     lines.push(

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -263,10 +263,11 @@ export default defineNuxtModule({
 
           if (!mockLines.length) return
 
-
-          if (shouldPrependMockHoist) {
-            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, {})});\n`)
-          }
+          s.prepend(`vi.hoisted(() => { 
+              if(!global.${HELPER_MOCK_HOIST}){
+                vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, {})
+              }
+            });\n`)
 
           if (!hasViImport) s.prepend(`import {vi} from "vitest";\n`)
 
@@ -274,9 +275,9 @@ export default defineNuxtModule({
 
           // do an import to trick vite to keep it
           // if not, the module won't be mocked
-          if(shouldPrependMockHoist) {
-            importPathsList.forEach((p) => { 
-              s.append( `\n import ${JSON.stringify(p)};`)
+          if (shouldPrependMockHoist) {
+            importPathsList.forEach((p) => {
+              s.append(`\n import ${JSON.stringify(p)};`)
             })
           }
 

--- a/packages/vitest-environment-nuxt/src/modules/mock.ts
+++ b/packages/vitest-environment-nuxt/src/modules/mock.ts
@@ -267,7 +267,7 @@ export default defineNuxtModule({
 
 
           if (shouldPrependMockHoist) {
-            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, { test:'lol' })});\n`)
+            s.prepend(`vi.hoisted(() => { vi.stubGlobal(${JSON.stringify(HELPER_MOCK_HOIST)}, {})});\n`)
           }
 
           if (!hasViImport) s.prepend(`import {vi} from "vitest";\n`)

--- a/playground/composables/auto-import-mock.ts
+++ b/playground/composables/auto-import-mock.ts
@@ -5,3 +5,11 @@ export function useAutoImportedTarget() {
 export function useAutoImportedNonTarget() {
   return 'the original'
 }
+
+export function useAutoImportSetupMocked() {
+  return 'the original'
+}
+
+export function useAutoImportSetupOverridenMocked() {
+  return 'the original'
+}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -8,6 +8,9 @@ export default defineNuxtConfig({
   vitest: {
     startOnBoot: true,
     logToConsole: true,
+    vitestConfig: {
+      setupFiles: ['./tests/setup/mocks']
+    }
   },
   imports: {
     injectAtEnd: true,

--- a/playground/tests/nuxt/auto-import-mock.spec.ts
+++ b/playground/tests/nuxt/auto-import-mock.spec.ts
@@ -12,7 +12,7 @@ mockNuxtImport<typeof useCustomModuleAutoImportedTarget>('useCustomModuleAutoImp
 mockNuxtImport<typeof useAutoImportSetupOverridenMocked>('useAutoImportSetupOverridenMocked', () => () => {
   return 'mocked in test file'
 })
-debugger
+
 it('should mock', () => {
   vi.fn()
   expect(useAutoImportedTarget()).toMatchInlineSnapshot('"mocked!"')

--- a/playground/tests/nuxt/auto-import-mock.spec.ts
+++ b/playground/tests/nuxt/auto-import-mock.spec.ts
@@ -9,10 +9,16 @@ mockNuxtImport<typeof useCustomModuleAutoImportedTarget>('useCustomModuleAutoImp
   return () => 'mocked!'
 })
 
+mockNuxtImport<typeof useAutoImportSetupOverridenMocked>('useAutoImportSetupOverridenMocked', () => () => {
+  return 'mocked in test file'
+})
+debugger
 it('should mock', () => {
   vi.fn()
   expect(useAutoImportedTarget()).toMatchInlineSnapshot('"mocked!"')
   expect(useAutoImportedNonTarget()).toMatchInlineSnapshot('"the original"')
+  expect(useAutoImportSetupOverridenMocked()).toMatchInlineSnapshot('"mocked in test file"')
+  expect(useAutoImportSetupMocked()).toMatchInlineSnapshot('"mocked in setup"')
 })
 
 it('should mock composable from external package', () => {

--- a/playground/tests/setup/mocks.ts
+++ b/playground/tests/setup/mocks.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest"
 import { mockNuxtImport } from "vitest-environment-nuxt/utils"
- 
+
 mockNuxtImport<typeof useAutoImportSetupMocked>('useAutoImportSetupMocked', () => vi.fn(() => {
   return 'mocked in setup'
 }))

--- a/playground/tests/setup/mocks.ts
+++ b/playground/tests/setup/mocks.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest"
+import { mockNuxtImport } from "vitest-environment-nuxt/utils"
+ 
+mockNuxtImport<typeof useAutoImportSetupMocked>('useAutoImportSetupMocked', () => vi.fn(() => {
+  return 'mocked in setup'
+}))
+
+mockNuxtImport<typeof useAutoImportSetupOverridenMocked>('useAutoImportSetupOverridenMocked', () => vi.fn(() => {
+  return 'mocked in setup'
+})) 
+ 

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -10,8 +10,10 @@ export default defineVitestConfig({
     environmentOptions: {
       nuxt: {
         rootDir: fileURLToPath(new URL('./', import.meta.url)),
-        domEnvironment: process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom',
+        domEnvironment: process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom' ?? 'happy-dom',
       },
-    },
+    }, 
+    setupFiles: ['./tests/setup/mocks.ts'], 
+    globals: true
   },
 })

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineVitestConfig({
         domEnvironment: process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom' ?? 'happy-dom',
       },
     }, 
-    setupFiles: ['./tests/setup/mocks.ts'], 
-    globals: true
+    setupFiles: ['./tests/setup/mocks.ts']
   },
 })


### PR DESCRIPTION
Hi :wave: 

This PR allows mocking imports within setup files. 

Currently if we can only use `mockNuxtImport` either within the setup file or within the test file.

The idea behind this PR is to use the new `vi.hoisted` from vitest 0.31 to set globally a `__NUXT_VITEST_MOCKS` variable which would contains all imports (mocked or not).

`mockNuxtImport` will instead of returning the module modified, assign the module within the `__NUXT_VITEST_MOCKS` variable, modify the mocked import and return `__NUXT_VITEST_MOCKS`