### PR TITLE
fix: vue-router with jsdom

### DIFF
--- a/packages/vitest-environment-nuxt/src/env/jsdom.ts
+++ b/packages/vitest-environment-nuxt/src/env/jsdom.ts
@@ -37,6 +37,10 @@ export default <EnvironmentNuxt> async function (global, { jsdom = {} }) {
     },
   ).window as any
 
+  // Vue-router relies on scrollTo being available if run in a browser.
+  // The scrollTo implementation from JSDOM throws a "Not Implemented" error
+  window.scrollTo = () => {}
+
   return {
     window,
     teardown() {}


### PR DESCRIPTION
Relates to https://github.com/danielroe/nuxt-vitest/pull/121#discussion_r1242044300

## Steps to reproduce

Run the unit tests (including the JSDOM ones): `pnpm test`

The logs will be full of this error:
![image](https://github.com/danielroe/nuxt-vitest/assets/324147/79616dbc-71e7-4667-b6bb-05eb0bccbb4e)

Note: we should definitely add running the JSDOM in CI as well. Currently there are tests failing related to `fetch` though, hence why I have not included this change in this PR.

## Problem

`vue-router` is throwing an error due to `window.scrollTo` in JSDOM not having a proper implementation. JSDOM has a placeholder function that throws a "not implemented" error. Thus we replace this with a noop to get rid of the error inside `vue-router`.

## Implementation

I tried fixing this in a local Vitest config by adding a setup file that adds `scrollTo`. This is unfortunately not possible since `nuxt-vitest` initializes before the setup files can add things to the JSDOM environment. Thus I think we have to add this in `nuxt-vitest`.