### PR TITLE
fix: improve fetch polyfill implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,11 @@ jobs:
       - name: 🛠 Build project
         run: pnpm build
 
-      - name: 🧪 Playground Test
+      - name: 🧪 Playground Test with Happy-DOM
         run: pnpm -C playground run test:unit --coverage
+
+      - name: 🧪 Playground Test with JSDOM
+        run: pnpm -C playground run test:jsdom --coverage
 
       - name: 🧪 Playground Test on Dev
         run: pnpm -C playground run test:dev

--- a/packages/vitest-environment-nuxt/package.json
+++ b/packages/vitest-environment-nuxt/package.json
@@ -50,9 +50,9 @@
     "estree-walker": "^3.0.3",
     "h3": "^1.6.5",
     "magic-string": "^0.30.0",
-    "node-fetch-native": "^1.2.0",
     "ofetch": "^1.0.0",
-    "unenv": "^1.0.2"
+    "unenv": "^1.0.2",
+    "whatwg-fetch": "3.6.17"
   },
   "devDependencies": {
     "@types/jsdom": "21.1.1",

--- a/packages/vitest-environment-nuxt/src/index.ts
+++ b/packages/vitest-environment-nuxt/src/index.ts
@@ -56,19 +56,19 @@ export default <Environment>{
 
     const h3App = createApp()
 
-    // If native fetch is not supported, polyfill it.
-    // Native fetch is considered unsupported in the following cases
-    //  - versions earlier than Node 16, 
-    //  - not enabling experimental-fetch in Node 17 
-    //  - enabling no-experimental-fetch in Node 18 and later.
-    if (!globalThis.fetch) {
-      // @ts-expect-error TODO: provide backwards compatible types
-      await import('node-fetch-native/polyfill')
+    // JSDOM does not include an implementation of window.fetch.
+    // `globalThis.fetch` is not available here for us to use
+    // the native standards compliant version, and node-fetch
+    // has issues in combination with JSDOM so we polyfill
+    // with cross-fetch here for JSDOM.
+    if (!win.fetch) {
+      // @ts-ignore skip types, we only polyfill
+      await import('whatwg-fetch')
     }
 
     // @ts-expect-error TODO: fix in h3
     const localCall = createCall(toNodeListener(h3App))
-    const localFetch = createLocalFetch(localCall, globalThis.fetch)
+    const localFetch = createLocalFetch(localCall, win.fetch)
 
     const registry = new Set<string>()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       magic-string:
         specifier: ^0.30.0
         version: 0.30.1
-      node-fetch-native:
-        specifier: ^1.2.0
-        version: 1.2.0
       ofetch:
         specifier: ^1.0.0
         version: 1.1.1
@@ -153,6 +150,9 @@ importers:
       vue-router:
         specifier: ^4.0.0
         version: 4.2.4(vue@3.3.4)
+      whatwg-fetch:
+        specifier: 3.6.17
+        version: 3.6.17
     devDependencies:
       '@types/jsdom':
         specifier: 21.1.1
@@ -1035,7 +1035,7 @@ packages:
       detect-libc: 2.0.1
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
@@ -1496,7 +1496,7 @@ packages:
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.2.3
       is-plain-object: 5.0.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -6724,8 +6724,8 @@ packages:
   /node-fetch-native@1.2.0:
     resolution: {integrity: sha512-5IAMBTl9p6PaAjYCnMv5FmqIF6GcZnawAVnzaCG0rX2aYZJ4CxEkZNtVPuTRug7fL7wyM5BQYTlAzcyMPi6oTQ==}
 
-  /node-fetch@2.6.9:
-    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+  /node-fetch@2.6.12:
+    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -10074,6 +10074,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
+
+  /whatwg-fetch@3.6.17:
+    resolution: {integrity: sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==}
+    dev: false
 
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}


### PR DESCRIPTION
## Problem

See details and triage in https://github.com/danielroe/nuxt-vitest/issues/278

## Implementation

It seems we cannot access `globalThis.fetch` during environment setup (it's always `undefined`), and `JSDOM` in incompatible with `node-fetch` (and by extension `node-fetch-native`) meaning we have to use some other `fetch` polyfill for JSDOM.

Thus I've made the following changes:
- For JSDOM we will now use `whatwg-fetch` which seems to be standard compliant, and passes all of the tests.
- For Happy-DOM we will now use its own `fetch` implementation (which seems to be a forked and better version of node-fetch).

I also added a step to CI to actually run the unit tests with JSDOM now that they're passing.