### PR TITLE
feat(nuxt-vitest): allow specifying vitest config path

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,4 @@
+
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   modules: [
@@ -8,6 +9,7 @@ export default defineNuxtConfig({
   vitest: {
     startOnBoot: true,
     logToConsole: true,
+    vitestConfigPath: './vitest.config'
   },
   imports: {
     injectAtEnd: true,


### PR DESCRIPTION
Hi :wave: 
this PR allow to directly specifying the vitest config path. A lot of users will likely customize their vitest configuration (including me 😅 ).

solves https://github.com/danielroe/nuxt-vitest/pull/274 `pnpm test:dev` issue