### PR TITLE
feat(nuxt-vitest): allow specifying vitest file config path

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -8,6 +8,7 @@ export default defineNuxtConfig({
   vitest: {
     startOnBoot: true,
     logToConsole: true,
+    vitestConfigPath: "./vitest.config"
   },
   imports: {
     injectAtEnd: true,

--- a/playground/tests/setup/global.ts
+++ b/playground/tests/setup/global.ts
@@ -1,0 +1,3 @@
+import {vi} from "vitest"
+
+vi.stubEnv('stubbed', 'true')

--- a/playground/tests/unit/setupMocks.spec.ts
+++ b/playground/tests/unit/setupMocks.spec.ts
@@ -1,0 +1,8 @@
+import { expect, describe, test } from "vitest"
+
+
+describe('test mock in setup file', () => {
+    test('stubbed env to be "true"', () => {
+        expect(process.env.stubbed).toBe('true')
+    })
+})

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -13,5 +13,6 @@ export default defineVitestConfig({
         domEnvironment: process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom',
       },
     },
+    setupFiles: ['./tests/setup/global']
   },
 })


### PR DESCRIPTION
Hi :wave: sorry for #280 😅 , 
This PR allow specifying the vitest config file path. Specifying the `vitestConfig` option will override the options from the vitest config.