### PR TITLE
feat: add `renderSuspended` for use with testing-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,43 @@ it('can also mount an app', async () => {
 })
 ```
 
+### `renderSuspended`
+
+`renderSuspended` allows you to render any vue component within the Nuxt environment using `@testing-library/vue`, allowing async setup and access to injections from your Nuxt plugins.
+
+This should be used together with utilities from testing-library, e.g. `screen` and `fireEvent`. Install [@testing-library/vue](https://testing-library.com/docs/vue-testing-library/intro) in your project to use these.
+Additionally testing-library also relies on testing globals for cleanup. You should turn these on in your [Vitest config](https://vitest.dev/config/#globals).
+
+The passed in component will be rendered inside a `<div id="test-wrapper"></div>`.
+
+
+Examples:
+
+```ts
+// tests/components/SomeComponents.nuxt.spec.ts
+import { renderSuspended } from 'nuxt-vitest/utils'
+import { screen } from '@testing-library/vue'
+
+it('can render some component', async () => {
+    await renderSuspended(SomeComponent)
+    expect(screen.getByText('This is an auto-imported component')).toBeDefined()
+})
+
+// tests/App.nuxt.spec.ts
+import { renderSuspended } from 'nuxt-vitest/utils'
+
+it('can also render an app', async () => {
+    const html = await renderSuspended(App, { route: '/test' })
+    expect(html()).toMatchInlineSnapshot(`
+      "<div id=\\"test-wrapper\\">
+        <div>This is an auto-imported component</div>
+        <div> I am a global component </div>
+        <div>Index page</div><a href=\\"/test\\"> Test link </a>
+      </div>"
+    `)
+})
+```
+
 ### `mockNuxtImport`
 
 `mockNuxtImport` allows you to mock Nuxt's auto import functionality. For example, to mock `useStorage`, you can do so like this:

--- a/packages/vitest-environment-nuxt/package.json
+++ b/packages/vitest-environment-nuxt/package.json
@@ -58,12 +58,14 @@
     "whatwg-fetch": "3.6.17"
   },
   "devDependencies": {
+    "@testing-library/vue": "7.0.0",
     "@types/jsdom": "21.1.1",
     "happy-dom": "10.5.2",
     "jsdom": "22.1.0",
     "vue": "3.3.4"
   },
   "peerDependencies": {
+    "@testing-library/vue": "7.0.0",
     "happy-dom": "^9.10.9 || ^10.0.0",
     "jsdom": "^22.0.0",
     "vitest": "^0.24.5 || ^0.26.0 || ^0.27.0 || ^0.28.0 || ^0.29.0 || ^0.30.0 || ^0.33.0",
@@ -71,6 +73,9 @@
     "vue-router": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@testing-library/vue": {
+      "optional": true
+    },
     "happy-dom": {
       "optional": true
     },

--- a/packages/vitest-environment-nuxt/src/runtime/render.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/render.ts
@@ -1,0 +1,140 @@
+import {
+    type DefineComponent,
+    type SetupContext,
+    Suspense,
+    h,
+    nextTick,
+} from 'vue'
+
+import {
+    type RenderOptions as TestingLibraryRenderOptions,
+    render as renderFromTestingLibrary,
+} from '@testing-library/vue'
+import { defu } from 'defu'
+import type { RouteLocationRaw } from 'vue-router'
+
+import { RouterLink } from './components/RouterLink'
+
+// @ts-expect-error virtual file
+import NuxtRoot from '#build/root-component.mjs'
+import { useRouter } from '#imports'
+
+export type RenderOptions = TestingLibraryRenderOptions & {
+  route?: RouteLocationRaw
+}
+
+export const WRAPPER_EL_ID = 'test-wrapper'
+
+/**
+ * `renderSuspended` allows you to mount any vue component within the Nuxt environment, allowing async setup and access to injections from your Nuxt plugins.
+ *
+ * This is a wrapper around the `render` function from @testing-libary/vue, and should be used together with
+ * utilities from that package.
+ *
+ * ```ts
+ * // tests/components/SomeComponents.nuxt.spec.ts
+ * import { renderSuspended } from 'nuxt-vitest/utils'
+ *
+ * it('can render some component', async () => {
+ *     const { html } = await renderSuspended(SomeComponent)
+ *     expect(html()).toMatchInlineSnapshot(
+ *         'This is an auto-imported component'
+ *     )
+ *
+ * })
+ *
+ * // tests/App.nuxt.spec.ts
+ * import { renderSuspended } from 'nuxt-vitest/utils'
+ * import { screen } from '@testing-library/vue'
+ *
+ * it('can also mount an app', async () => {
+ *     const { html } = await renderSuspended(App, { route: '/test' })
+ *     expect(screen.getByRole('link', { name: 'Test Link' })).toBeVisible()
+ * })
+ * ```
+ *
+ * @param component the component to be tested
+ * @param options optional options to set up your component
+ */
+export async function renderSuspended<T>(
+  component: T,
+  options?: RenderOptions,
+) {
+  const {
+    props = {},
+    attrs = {},
+    slots = {},
+    route = '/',
+    ..._options
+  } = options || {}
+
+  // @ts-ignore untyped global __unctx__
+  const { vueApp } = globalThis.__unctx__.get('nuxt-app').tryUse()
+  const { render, setup } = component as DefineComponent<any, any>
+
+  let setupContext: SetupContext
+
+  return new Promise<ReturnType<typeof renderFromTestingLibrary>>((resolve) => {
+    const utils = renderFromTestingLibrary(
+      {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        setup: (props: any, ctx: any) => {
+          setupContext = ctx
+
+          return NuxtRoot.setup(props, {
+            ...ctx,
+            expose: () => {},
+          })
+        },
+        render: (renderContext: any) =>
+          // See discussions in https://github.com/testing-library/vue-testing-library/issues/230
+          // we add this additional root element because otherwise testing-library breaks
+          // because there's no root element while Suspense is resolving
+          h(
+            'div',
+            { id: WRAPPER_EL_ID },
+            h(
+              Suspense,
+              { onResolve: () => nextTick().then(() => resolve(utils)) },
+              {
+                default: () =>
+                  h({
+                    async setup() {
+                      const router = useRouter()
+                      await router.replace(route)
+
+                      // Proxy top-level setup/render context so test wrapper resolves child component
+                      const clonedComponent = {
+                        ...component,
+                        render: render
+                          ? (_ctx: any, ...args: any[]) =>
+                              render(renderContext, ...args)
+                          : undefined,
+                        setup: setup
+                          ? // eslint-disable-next-line @typescript-eslint/no-shadow
+                            (props: Record<string, any>) =>
+                              setup(props, setupContext)
+                          : undefined,
+                      }
+
+                      return () =>
+                        h(clonedComponent, { ...props, ...attrs }, slots)
+                    },
+                  }),
+              },
+            ),
+          ),
+      },
+      defu(_options, {
+        slots,
+        global: {
+          config: {
+            globalProperties: vueApp.config.globalProperties,
+          },
+          provide: vueApp._context.provides,
+          components: { RouterLink },
+        },
+      }),
+    )
+  })
+}

--- a/packages/vitest-environment-nuxt/src/utils.ts
+++ b/packages/vitest-environment-nuxt/src/utils.ts
@@ -1,2 +1,3 @@
 export { registerEndpoint, mockNuxtImport, mockComponent } from './runtime/mock'
 export { mountSuspended } from './runtime/mount'
+export { renderSuspended } from './runtime/render'

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "0.8.0",
+    "@testing-library/vue": "7.0.0",
     "happy-dom": "10.5.2",
     "jsdom": "22.1.0",
     "nuxt": "3.6.5",

--- a/playground/tests/nuxt/utils-render.spec.ts
+++ b/playground/tests/nuxt/utils-render.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, it, expect } from 'vitest'
+import { renderSuspended } from 'vitest-environment-nuxt/utils'
+import { cleanup, fireEvent, screen } from '@testing-library/vue'
+
+import App from '~/app.vue'
+import OptionsComponent from '~/components/OptionsComponent.vue'
+import WrapperTests from '~/components/WrapperTests.vue'
+
+describe('test utils', () => {
+  describe('renderSuspended', () => {
+
+    afterEach(() => {
+      // since we're not running with Vitest globals when running the tests
+      // from inside the test server. This means testing-library cannot
+      // auto-attach the cleanup go testing globals, and we have to do
+      // it here manually.
+      if (process.env.NUXT_VITEST_DEV_TEST) {
+        cleanup()
+      }
+    })
+
+    it('can render components within nuxt suspense', async () => {
+      const { html } = await renderSuspended(App)
+      expect(html()).toMatchInlineSnapshot(`
+        "<div id=\\"test-wrapper\\">
+          <div>This is an auto-imported component</div>
+          <div> I am a global component </div>
+          <div>Index page</div><a href=\\"/test\\"> Test link </a>
+        </div>"
+      `)
+    })
+
+    it('should render default props within nuxt suspense', async () => {
+      await renderSuspended(OptionsComponent)
+      expect(screen.getByRole('heading', { level: 2 })).toMatchInlineSnapshot(
+        `
+        <h2>
+          The original
+        </h2>
+      `
+      )
+    })
+
+    it('should render passed props within nuxt suspense', async () => {
+      await renderSuspended(OptionsComponent, {
+        props: {
+          title: 'title from mount suspense props',
+        },
+      })
+      expect(screen.getByRole('heading', { level: 2 })).toMatchInlineSnapshot(
+        `
+        <h2>
+          title from mount suspense props
+        </h2>
+      `
+      )
+    })
+
+    it('can pass slots to rendered components within nuxt suspense', async () => {
+      const text = 'slot from mount suspense'
+      await renderSuspended(OptionsComponent, {
+        slots: {
+          default: () => text,
+        },
+      })
+      expect(screen.getByText(text)).toBeDefined()
+    })
+
+    it('can receive emitted events from components rendered within nuxt suspense', async () => {
+      const { emitted } = await renderSuspended(WrapperTests)
+      const button = screen.getByRole('button', {name: 'Click me!'})
+      await fireEvent.click(button)
+
+      const emittedEvents = emitted()
+      expect(emittedEvents.click).toMatchObject(
+        expect.arrayContaining([
+          expect.arrayContaining([expect.objectContaining({ type: 'click' })]),
+        ])
+      )
+
+      // since this is a native event it doesn't serialize well
+      delete emittedEvents.click
+      expect(emittedEvents).toMatchInlineSnapshot(`
+        {
+          "customEvent": [
+            [
+              "foo",
+            ],
+          ],
+          "otherEvent": [
+            [],
+          ],
+        }
+      `)
+    })
+  })
+})

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -12,7 +12,8 @@ export default defineVitestConfig({
         rootDir: fileURLToPath(new URL('./', import.meta.url)),
         domEnvironment: process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom' ?? 'happy-dom',
       },
-    }, 
-    setupFiles: ['./tests/setup/mocks.ts']
+    },
+    setupFiles: ['./tests/setup/mocks.ts'],
+    globals: true
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
         specifier: 3.6.17
         version: 3.6.17
     devDependencies:
+      '@testing-library/vue':
+        specifier: 7.0.0
+        version: 7.0.0(@vue/compiler-sfc@3.3.4)(vue@3.3.4)
       '@types/jsdom':
         specifier: 21.1.1
         version: 21.1.1
@@ -178,6 +181,9 @@ importers:
       '@nuxt/devtools':
         specifier: 0.8.0
         version: 0.8.0(nuxt@3.6.5)(rollup@3.26.0)(vite@4.3.9)
+      '@testing-library/vue':
+        specifier: 7.0.0
+        version: 7.0.0(@vue/compiler-sfc@3.3.4)(vue@3.3.4)
       happy-dom:
         specifier: 10.5.2
         version: 10.5.2
@@ -468,6 +474,13 @@ packages:
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.21.4)
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/runtime@7.22.10:
+    resolution: {integrity: sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: true
 
   /@babel/standalone@7.21.4:
     resolution: {integrity: sha512-Rw4nGqH/iyVeYxARKcz7iGP+njkPsVqJ45TmXMONoGoxooWjXCAs+CUcLeAZdBGCLqgaPvHKCYvIaDT2Iq+KfA==}
@@ -1548,7 +1561,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dependencies:
       cross-spawn: 7.0.3
-      fast-glob: 3.3.0
+      fast-glob: 3.3.1
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.0
@@ -1798,6 +1811,34 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
+  /@testing-library/dom@9.3.1:
+    resolution: {integrity: sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      '@babel/runtime': 7.22.10
+      '@types/aria-query': 5.0.1
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+    dev: true
+
+  /@testing-library/vue@7.0.0(@vue/compiler-sfc@3.3.4)(vue@3.3.4):
+    resolution: {integrity: sha512-JU/q93HGo2qdm1dCgWymkeQlfpC0/0/DBZ2nAHgEAsVZxX11xVIxT7gbXdI7HACQpUbsUWt1zABGU075Fzt9XQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@vue/compiler-sfc': '>= 3'
+      vue: '>= 3'
+    dependencies:
+      '@babel/runtime': 7.22.10
+      '@testing-library/dom': 9.3.1
+      '@vue/compiler-sfc': 3.3.4
+      '@vue/test-utils': 2.3.2(vue@3.3.4)
+      vue: 3.3.4
+    dev: true
+
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -1822,6 +1863,10 @@ packages:
     dependencies:
       '@tufjs/canonical-json': 1.0.0
       minimatch: 7.4.6
+    dev: true
+
+  /@types/aria-query@5.0.1:
+    resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
 
   /@types/chai-subset@1.3.3:
@@ -2353,7 +2398,6 @@ packages:
     optionalDependencies:
       '@vue/compiler-dom': 3.3.4
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
-    dev: false
 
   /@vue/typescript@1.8.8(typescript@5.1.6):
     resolution: {integrity: sha512-jUnmMB6egu5wl342eaUH236v8tdcEPXXkPgj+eI/F6JwW/lb+yAU6U07ZbQ3MVabZRlupIlPESB7ajgAGixhow==}
@@ -2563,6 +2607,19 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: true
+
+  /aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+    dependencies:
+      deep-equal: 2.2.2
+    dev: true
+
+  /array-buffer-byte-length@1.0.0:
+    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
+    dependencies:
+      call-bind: 1.0.2
+      is-array-buffer: 3.0.2
     dev: true
 
   /array-ify@1.0.0:
@@ -2934,7 +2991,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
     dev: true
 
   /callsites@3.1.0:
@@ -3693,6 +3750,29 @@ packages:
     dependencies:
       type-detect: 4.0.8
 
+  /deep-equal@2.2.2:
+    resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.2
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.2.1
+      is-arguments: 1.1.1
+      is-array-buffer: 3.0.2
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      isarray: 2.0.5
+      object-is: 1.1.5
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.5.0
+      side-channel: 1.0.4
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.9
+    dev: true
+
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3837,6 +3917,10 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+    dev: true
+
   /dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
@@ -3911,7 +3995,6 @@ packages:
       lru-cache: 4.1.5
       semver: 5.7.1
       sigmund: 1.0.1
-    dev: false
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4047,7 +4130,7 @@ packages:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has-symbols: 1.0.3
       is-arguments: 1.1.1
       is-map: 2.0.2
@@ -4061,7 +4144,7 @@ packages:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: true
@@ -4735,6 +4818,15 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /get-intrinsic@1.2.1:
+    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+    dev: true
+
   /get-pkg-repo@4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
     engines: {node: '>=6.9.0'}
@@ -4767,7 +4859,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
     dev: true
 
   /get-tsconfig@4.5.0:
@@ -4945,7 +5037,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
     dev: true
 
   /got@12.6.1:
@@ -5349,7 +5441,7 @@ packages:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
@@ -5404,7 +5496,15 @@ packages:
     resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
+      is-typed-array: 1.1.10
+    dev: true
+
+  /is-array-buffer@3.0.2:
+    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
       is-typed-array: 1.1.10
     dev: true
 
@@ -5697,10 +5797,21 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /is-weakmap@2.0.1:
+    resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
+    dev: true
+
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
+    dev: true
+
+  /is-weakset@2.0.2:
+    resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
     dev: true
 
   /is-wsl@2.2.0:
@@ -5804,7 +5915,6 @@ packages:
       editorconfig: 0.15.3
       glob: 8.1.0
       nopt: 6.0.0
-    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6181,7 +6291,6 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
-    dev: false
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -6202,6 +6311,11 @@ packages:
   /lru-cache@9.1.1:
     resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
     engines: {node: 14 || >=16.14}
+    dev: true
+
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
     dev: true
 
   /macos-release@3.1.0:
@@ -7891,6 +8005,15 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     dev: true
 
+  /pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: true
+
   /pretty-format@29.6.1:
     resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7976,7 +8099,6 @@ packages:
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-    dev: false
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -8037,6 +8159,10 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    dev: true
+
+  /react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
   /react-is@18.2.0:
@@ -8172,8 +8298,21 @@ packages:
       redis-errors: 1.2.0
     dev: true
 
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: true
+
   /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      functions-have-names: 1.2.3
+    dev: true
+
+  /regexp.prototype.flags@1.5.0:
+    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -8399,7 +8538,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       is-regex: 1.1.4
     dev: true
 
@@ -8535,7 +8674,7 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       object-inspect: 1.12.3
     dev: true
 
@@ -8544,7 +8683,6 @@ packages:
 
   /sigmund@1.0.1:
     resolution: {integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==}
-    dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -10137,6 +10275,15 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /which-collection@1.0.1:
+    resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
+    dependencies:
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-weakmap: 2.0.1
+      is-weakset: 2.0.2
+    dev: true
+
   /which-typed-array@1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
     engines: {node: '>= 0.4'}
@@ -10282,7 +10429,6 @@ packages:
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
-    dev: false
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}


### PR DESCRIPTION
Resolves https://github.com/danielroe/nuxt-vitest/issues/271

This PR adds a new utility function: `renderSuspended`. This works similarly to `mountSuspended` but instead of @vue/test-utils uses @testing-library/vue and its `render` function.

The implementation is almost a duplicate of `mountSuspended` with the difference being that we wrap the root element in a div. This is necessary for `@testing-library/vue` to be able to render `Suspended`.

*TODOs*
- [x] Add tests 
- [x] Update docs in README

*Open questions*
- Should this add `@testing-library/vue` as an optional peer dependency or a mandatory one?
