### PR TITLE
chore: fix tests on Windows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 shamefully-hoist=true
 resolution-mode=highest
+shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "packageManager": "pnpm@8.6.12",
   "scripts": {
-    "build": "pnpm dev:prepare && pnpm run --filter=./packages/* -r build",
-    "stub": "pnpm -r --filter=\"./packages/**\" run stub",
+    "build": "pnpm dev:prepare && pnpm -r --filter \"./packages/**\" run build",
+    "stub": "pnpm -r --filter \"./packages/**\" run stub",
     "dev:prepare": "pnpm stub && pnpm nuxi prepare playground",
     "dev": "pnpm run build && pnpm -C playground test:unit",
     "lint": "pnpm lint:all:eslint && pnpm lint:all:prettier",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@8.6.12",
   "scripts": {
     "build": "pnpm dev:prepare && pnpm run --filter=./packages/* -r build",
-    "stub": "pnpm run --filter=./packages/* -r stub",
+    "stub": "pnpm -r --filter \"./packages/**\" run stub",
     "dev:prepare": "pnpm stub && pnpm nuxi prepare playground",
     "dev": "pnpm run build && pnpm -C playground test:unit",
     "lint": "pnpm lint:all:eslint && pnpm lint:all:prettier",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@8.6.12",
   "scripts": {
     "build": "pnpm dev:prepare && pnpm run --filter=./packages/* -r build",
-    "stub": "pnpm -r --filter \"./packages/**\" run stub",
+    "stub": "pnpm -r --filter=\"./packages/**\" run stub",
     "dev:prepare": "pnpm stub && pnpm nuxi prepare playground",
     "dev": "pnpm run build && pnpm -C playground test:unit",
     "lint": "pnpm lint:all:eslint && pnpm lint:all:prettier",


### PR DESCRIPTION
Enable shell-emulator

Running `stub` script, we should also update it:

![imagen](https://github.com/danielroe/nuxt-vitest/assets/6311119/cbdb146c-bddd-45f8-b99a-665d30a97534)


closes #225