### PR TITLE
fix: add node10 types for `vitest-environment-nuxt`

### DIFF
--- a/packages/vitest-environment-nuxt/package.json
+++ b/packages/vitest-environment-nuxt/package.json
@@ -22,6 +22,7 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./utils": {
       "types": "./dist/utils.d.ts",


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=vitest-environment-nuxt%400.10.2