### PR TITLE
fix(vitest-environment-nuxt): import `@testing-library/vue` within `renderSuspended`

### DIFF
--- a/packages/vitest-environment-nuxt/src/runtime/render.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/render.ts
@@ -5,10 +5,9 @@ import {
   h,
   nextTick,
 } from 'vue'
-
-import {
-  type RenderOptions as TestingLibraryRenderOptions,
-  render as renderFromTestingLibrary,
+import { importModule } from 'local-pkg'
+import type {
+   RenderOptions as TestingLibraryRenderOptions,
 } from '@testing-library/vue'
 import { defu } from 'defu'
 import type { RouteLocationRaw } from 'vue-router'
@@ -67,6 +66,8 @@ export async function renderSuspended<T>(
     route = '/',
     ..._options
   } = options || {}
+
+  const { render : renderFromTestingLibrary } = await importModule<typeof import('@testing-library/vue')>('@testing-library/vue')
 
   // @ts-ignore untyped global __unctx__
   const { vueApp } = globalThis.__unctx__.get('nuxt-app').tryUse()

--- a/packages/vitest-environment-nuxt/src/runtime/render.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/render.ts
@@ -5,7 +5,6 @@ import {
   h,
   nextTick,
 } from 'vue'
-import { importModule } from 'local-pkg'
 import type {
    RenderOptions as TestingLibraryRenderOptions,
 } from '@testing-library/vue'
@@ -67,7 +66,7 @@ export async function renderSuspended<T>(
     ..._options
   } = options || {}
 
-  const { render : renderFromTestingLibrary } = await importModule<typeof import('@testing-library/vue')>('@testing-library/vue')
+  const { render : renderFromTestingLibrary } = await import('@testing-library/vue')
 
   // @ts-ignore untyped global __unctx__
   const { vueApp } = globalThis.__unctx__.get('nuxt-app').tryUse()


### PR DESCRIPTION
Hi :wave: 

This PR resolves #330 , this removes the import from `@testing-library/vue` in the final build of the utils file