### PR TITLE
feat(utils): add method option to `registerEndpoint`

### DIFF
--- a/packages/vitest-environment-nuxt/src/runtime/mock.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/mock.ts
@@ -56,7 +56,7 @@ export function registerEndpoint(
 
   app.use('/_' + url, defineEventHandler(config.handler), {
     match(_, event) {
-      return config.method ? event.method === config.method : true
+      return config.method ? event?.method === config.method : true
     },
   })
 

--- a/playground/tests/nuxt/index.spec.ts
+++ b/playground/tests/nuxt/index.spec.ts
@@ -39,19 +39,20 @@ describe('client-side nuxt features', () => {
 
   it('allows pushing to other pages', async () => {
     await navigateTo('/something')
-    expect(useNuxtApp().$router.currentRoute.value.path).toEqual(
-      '/something'
-    )
+    expect(useNuxtApp().$router.currentRoute.value.path).toEqual('/something')
     // It takes a few ticks for the Nuxt useRoute to be updated (as, after suspense resolves,
     // we wait for a final hook and then update the injected route object )
     const route = useRoute()
     await new Promise<void>(resolve => {
-      const unsub = watch(() => route.path, path => {
-        if (path === '/something') {
-          unsub()
-          resolve()
+      const unsub = watch(
+        () => route.path,
+        path => {
+          if (path === '/something') {
+            unsub()
+            resolve()
+          }
         }
-      })
+      )
     })
     expect(route.path).toEqual('/something')
   })
@@ -115,10 +116,15 @@ describe('test utils', () => {
   })
 
   it('can use $fetch', async () => {
-    const app = createApp().use('/todos/1', eventHandler(() => ({ id: 1 })))
+    const app = createApp().use(
+      '/todos/1',
+      eventHandler(() => ({ id: 1 }))
+    )
     const server = await listen(toNodeListener(app))
     const [{ url }] = await server.getURLs()
-    expect(await $fetch<unknown>('/todos/1', { baseURL: url })).toMatchObject({ id: 1 })
+    expect(await $fetch<unknown>('/todos/1', { baseURL: url })).toMatchObject({
+      id: 1,
+    })
     await server.close()
   })
 
@@ -130,6 +136,21 @@ describe('test utils', () => {
     expect(component.html()).toMatchInlineSnapshot(
       '"<div>title from mocked api</div>"'
     )
+  })
+
+  it('can mock fetch requests with explicit methods', async () => {
+    registerEndpoint('/method', {
+      method: 'POST',
+      handler: () => ({ method: 'POST' }),
+    })
+    registerEndpoint('/method', {
+      method: 'GET',
+      handler: () => ({ method: 'GET' }),
+    })
+    expect(await $fetch<unknown>('/method', { method: 'POST' })).toMatchObject({
+      method: 'POST',
+    })
+    expect(await $fetch<unknown>('/method')).toMatchObject({ method: 'GET' })
   })
 
   // TODO: reenable when merging Nuxt 3.7


### PR DESCRIPTION
This PR lets you specify an optional HTTP method for a given endpoint so that one can mock different responses/behavior depending on said method.