### PR TITLE
feat: allow `indexedDB` mock + disabling `IntersectionObserver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ When you run your tests within the Nuxt environment, they will be running in a [
 
 This means you should be take particular care not to mutate the global state in your tests (or, if you have, to reset it afterwards).
 
+## 🎭 Built-in mocks
+
+`nuxt-vitest` provides some built-in mocks for the DOM environment, both for `happy-dom` and `jsdom`.
+
+#### `intersectionObserver`
+Default `true`, creates a dummy class without any functionality for the IntersectionObserver API
+
+
+#### `indexedDB`
+Default `false`, uses [`fake-indexeddb`](https://github.com/dumbmatter/fakeIndexedDB) to create a functional mock of the IndexedDB API
+
+These can be configured in the `environmentOptions` section of your `vitest.config.mjs` file:
+
+```js
+export default defineVitestConfig({
+  test: {
+    environmentOptions: {
+        mock: {
+          intersectionObserver: true,
+          indexedDb: true,
+        },
+      },
+    },
+  },
+})
+````
+
 ## 🛠️ Helpers
 
 `nuxt-vitest` provides a number of helpers to make testing Nuxt apps easier.

--- a/README.md
+++ b/README.md
@@ -120,13 +120,14 @@ These can be configured in the `environmentOptions` section of your `vitest.conf
 export default defineVitestConfig({
   test: {
     environmentOptions: {
+      nuxt: {
         mock: {
           intersectionObserver: true,
           indexedDb: true,
-        },
-      },
-    },
-  },
+        }
+      }
+    }
+  }
 })
 ````
 

--- a/packages/nuxt-vitest/src/config.ts
+++ b/packages/nuxt-vitest/src/config.ts
@@ -114,6 +114,11 @@ export async function getVitestConfigFromNuxt(
         nuxt: {
           rootId: options.nuxt.options.app.rootId || undefined,
           ...options.viteConfig.test?.environmentOptions?.nuxt,
+          mock: {
+            intersectionObserver: true,
+            indexedDb: false,
+            ...options.viteConfig.test?.environmentOptions?.nuxt?.mock,
+          },
         },
         nuxtRuntimeConfig: options.nuxt.options.runtimeConfig,
         nuxtRouteRules: defu({}, options.nuxt.options.routeRules, options.nuxt.options.nitro?.routeRules)
@@ -181,6 +186,11 @@ declare module 'vitest' {
        * @default {happy-dom}
        */
       domEnvironment?: 'happy-dom' | 'jsdom'
+
+      mock?: {
+        intersectionObserver?: boolean
+        indexedDb?: boolean
+      }
     }
   }
 }

--- a/packages/vitest-environment-nuxt/package.json
+++ b/packages/vitest-environment-nuxt/package.json
@@ -50,6 +50,7 @@
     "@vue/test-utils": "^2.4.1",
     "defu": "^6.1.2",
     "estree-walker": "^3.0.3",
+    "fake-indexeddb": "^4.0.2",
     "h3": "^1.8.1",
     "local-pkg": "^0.5.0",
     "magic-string": "^0.30.3",

--- a/packages/vitest-environment-nuxt/src/index.ts
+++ b/packages/vitest-environment-nuxt/src/index.ts
@@ -1,5 +1,6 @@
 import type { Environment } from 'vitest'
 import { createFetch } from 'ofetch'
+import { indexedDB } from 'fake-indexeddb'
 import { joinURL } from 'ufo'
 import { createApp, defineEventHandler, toNodeListener } from 'h3'
 import { createRouter as createRadixRouter, exportMatcher, toRouteMatcher } from 'radix3'
@@ -53,13 +54,20 @@ export default <Environment>{
     app.id = environmentOptions.nuxt.rootId
     win.document.body.appendChild(app)
 
-    win.IntersectionObserver =
-      win.IntersectionObserver ||
-      class IntersectionObserver {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
-      }
+    if (environmentOptions?.nuxt?.mock?.intersectionObserver) {
+      win.IntersectionObserver =
+        win.IntersectionObserver ||
+        class IntersectionObserver {
+          observe() {}
+          unobserve() {}
+          disconnect() {}
+        }
+    }
+
+    if (environmentOptions?.nuxt?.mock?.indexedDb) {
+      // @ts-expect-error win.indexedDB is read-only
+      win.indexedDB = indexedDB
+    }
 
     const h3App = createApp()
 

--- a/playground/components/IndexedDbComponent.vue
+++ b/playground/components/IndexedDbComponent.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <h1>IndexedDbComponent</h1>
+    <pre>{{ retrievedValue }}</pre>
+  </div>
+</template>
+<script setup lang="ts">
+import { get, set } from 'idb-keyval'
+
+const props = defineProps<{ title: string }>()
+
+const app = useNuxtApp()
+const store = app.$store
+
+await set('data', props.title, store)
+
+const retrievedValue = await get('data', store)
+</script>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,6 +6,13 @@ export default defineNuxtConfig({
     logToConsole: true,
     vitestConfig: {
       setupFiles: ['./tests/setup/mocks'],
+      environmentOptions: {
+        nuxt: {
+          mock: {
+            indexedDb: true,
+          },
+        },
+      },
     },
   },
   imports: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -25,5 +25,8 @@
     "vitest-environment-nuxt": "0.11.0",
     "vue-tsc": "1.8.15"
   },
-  "version": "0.10.2"
+  "version": "0.10.2",
+  "dependencies": {
+    "idb-keyval": "^6.2.1"
+  }
 }

--- a/playground/plugins/indexeddb.ts
+++ b/playground/plugins/indexeddb.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'idb-keyval'
 
-export default defineNuxtPlugin(nuxt => {
+export default defineNuxtPlugin(() => {
   const store = createStore('my-db', 'my-store')
 
   return {

--- a/playground/plugins/indexeddb.ts
+++ b/playground/plugins/indexeddb.ts
@@ -1,0 +1,11 @@
+import { createStore } from 'idb-keyval'
+
+export default defineNuxtPlugin(nuxt => {
+  const store = createStore('my-db', 'my-store')
+
+  return {
+    provide: {
+      store,
+    },
+  }
+})

--- a/playground/tests/nuxt/mock-indexeddb.spec.ts
+++ b/playground/tests/nuxt/mock-indexeddb.spec.ts
@@ -1,0 +1,18 @@
+import { expect, it } from 'vitest'
+import { mountSuspended } from 'vitest-environment-nuxt/utils'
+import IndexedDbComponent from '~/components/IndexedDbComponent.vue'
+
+// Mocking of indexedDB can be enabled in vite.config.ts
+
+it('should mock indexeddb', async () => {
+  const component = await mountSuspended(IndexedDbComponent, {
+    props: {
+      title: 'Hello world',
+    },
+  })
+  expect(component.html()).toMatchInlineSnapshot(`
+    "<div>
+      <h1>IndexedDbComponent</h1><pre>Hello world</pre>
+    </div>"
+  `)
+})

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineVitestConfig({
         rootDir: fileURLToPath(new URL('./', import.meta.url)),
         domEnvironment:
           (process.env.VITEST_DOM_ENV as 'happy-dom' | 'jsdom') ?? 'happy-dom',
+
+        mock: {
+          indexedDb: true,
+        },
       },
     },
     setupFiles: ['./tests/setup/mocks.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 15.0.2
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
+        version: 3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
       prettier:
         specifier: 3.0.3
         version: 3.0.3
@@ -104,7 +104,7 @@ importers:
         version: 3.7.4(rollup@3.29.4)
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
+        version: 3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
       vitest:
         specifier: 0.33.0
         version: 0.33.0(@vitest/ui@0.33.0)
@@ -178,7 +178,7 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: 1.0.0
-        version: 1.0.0(nuxt@3.7.4)(rollup@3.29.4)(vite@4.4.11)
+        version: 1.0.0(idb-keyval@6.2.1)(nuxt@3.7.4)(rollup@3.29.4)(vite@4.4.11)
       '@testing-library/vue':
         specifier: 7.0.0
         version: 7.0.0(@vue/compiler-sfc@3.3.4)(vue@3.3.4)
@@ -190,7 +190,7 @@ importers:
         version: 22.1.0
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
+        version: 3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
       nuxt-vitest:
         specifier: workspace:*
         version: link:../packages/nuxt-vitest
@@ -1192,7 +1192,7 @@ packages:
       '@nuxt/kit': 3.7.4(rollup@3.29.4)
       '@nuxt/schema': 3.7.4(rollup@3.29.4)
       execa: 7.2.0
-      nuxt: 3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
+      nuxt: 3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
       vite: 4.4.11(@types/node@20.8.3)
     transitivePeerDependencies:
       - rollup
@@ -1215,7 +1215,7 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@nuxt/devtools@1.0.0(nuxt@3.7.4)(rollup@3.29.4)(vite@4.4.11):
+  /@nuxt/devtools@1.0.0(idb-keyval@6.2.1)(nuxt@3.7.4)(rollup@3.29.4)(vite@4.4.11):
     resolution: {integrity: sha512-pM5AvystXlFPYOsGbH8PBxEYkttiEWHsZnGw660iMw8QedB6mAweT21XX9LDS69cqnRY5uTFqVOmO9Y4EYL3hg==}
     hasBin: true
     peerDependencies:
@@ -1242,8 +1242,8 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.0
-      nitropack: 2.6.3
-      nuxt: 3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
+      nitropack: 2.6.3(idb-keyval@6.2.1)
+      nuxt: 3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19)
       nypm: 0.3.3
       ofetch: 1.3.3
       ohash: 1.1.3
@@ -5688,7 +5688,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt@3.7.4(eslint@8.51.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19):
+  /nuxt@3.7.4(eslint@8.51.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.19):
     resolution: {integrity: sha512-voXN2kheEpi7DJd0hkikfLuA41UiP9IwDDol65dvoJiHnRseWfaw1MyJl6FLHHDHwRzisX9QXWIyMfa9YF4nGg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 14.0.1
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
+        version: 3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
       prettier:
         specifier: 3.0.3
         version: 3.0.3
@@ -104,7 +104,7 @@ importers:
         version: 3.7.4(rollup@3.29.4)
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
+        version: 3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
       vitest:
         specifier: 0.33.0
         version: 0.33.0(@vitest/ui@0.33.0)
@@ -123,6 +123,9 @@ importers:
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
+      fake-indexeddb:
+        specifier: ^4.0.2
+        version: 4.0.2
       h3:
         specifier: ^1.8.1
         version: 1.8.2
@@ -168,6 +171,10 @@ importers:
         version: 3.3.4
 
   playground:
+    dependencies:
+      idb-keyval:
+        specifier: ^6.2.1
+        version: 6.2.1
     devDependencies:
       '@nuxt/devtools':
         specifier: 0.8.5
@@ -183,7 +190,7 @@ importers:
         version: 22.1.0
       nuxt:
         specifier: 3.7.4
-        version: 3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
+        version: 3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
       nuxt-vitest:
         specifier: workspace:*
         version: link:../packages/nuxt-vitest
@@ -1195,7 +1202,7 @@ packages:
       '@nuxt/kit': 3.7.4(rollup@3.29.4)
       '@nuxt/schema': 3.7.4(rollup@3.29.4)
       execa: 7.2.0
-      nuxt: 3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
+      nuxt: 3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
       vite: 4.4.11(@types/node@20.8.3)
     transitivePeerDependencies:
       - rollup
@@ -1244,7 +1251,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.4.3
       magicast: 0.3.0
-      nuxt: 3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
+      nuxt: 3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15)
       nypm: 0.3.3
       ofetch: 1.3.3
       ohash: 1.1.3
@@ -1533,6 +1540,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -2643,6 +2651,11 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /base64-arraybuffer-es6@0.7.0:
+    resolution: {integrity: sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
@@ -3411,6 +3424,12 @@ packages:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
     dev: true
 
+  /domexception@1.0.1:
+    resolution: {integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==}
+    dependencies:
+      webidl-conversions: 4.0.2
+    dev: false
+
   /domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
@@ -3836,6 +3855,12 @@ packages:
       pathe: 1.1.1
       ufo: 1.3.1
     dev: true
+
+  /fake-indexeddb@4.0.2:
+    resolution: {integrity: sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==}
+    dependencies:
+      realistic-structured-clone: 3.0.0
+    dev: false
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4402,6 +4427,9 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+
+  /idb-keyval@6.2.1:
+    resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
 
   /ignore-walk@6.0.3:
     resolution: {integrity: sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==}
@@ -5046,7 +5074,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /log-update@5.0.1:
     resolution: {integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==}
@@ -5415,6 +5442,10 @@ packages:
     hasBin: true
     dev: true
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: true
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -5424,7 +5455,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /nitropack@2.6.3:
+  /nitropack@2.6.3(idb-keyval@6.2.1):
     resolution: {integrity: sha512-k1GC9GiIrjAmLx48g52/38u6OfWVUAhvWtxm5G4vFUaGAt82WPVl+P5S9YXMRXgNtUnTFfzC4Vfp5TUEG0i7zQ==}
     engines: {node: ^16.11.0 || >=17.0.0}
     hasBin: true
@@ -5496,7 +5527,7 @@ packages:
       unctx: 2.3.1
       unenv: 1.7.4
       unimport: 3.4.0(rollup@3.29.4)
-      unstorage: 1.9.0
+      unstorage: 1.9.0(idb-keyval@6.2.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5707,7 +5738,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt@3.7.4(eslint@8.50.0)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15):
+  /nuxt@3.7.4(eslint@8.50.0)(idb-keyval@6.2.1)(rollup@3.29.4)(typescript@5.2.2)(vue-tsc@1.8.15):
     resolution: {integrity: sha512-voXN2kheEpi7DJd0hkikfLuA41UiP9IwDDol65dvoJiHnRseWfaw1MyJl6FLHHDHwRzisX9QXWIyMfa9YF4nGg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -5749,7 +5780,7 @@ packages:
       knitwork: 1.0.0
       magic-string: 0.30.4
       mlly: 1.4.2
-      nitropack: 2.6.3
+      nitropack: 2.6.3(idb-keyval@6.2.1)
       nuxi: 3.9.0
       nypm: 0.3.3
       ofetch: 1.3.3
@@ -6609,6 +6640,14 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
+  /realistic-structured-clone@3.0.0:
+    resolution: {integrity: sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==}
+    dependencies:
+      domexception: 1.0.1
+      typeson: 6.1.0
+      typeson-registry: 1.0.0-alpha.39
+    dev: false
+
   /redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -7278,6 +7317,13 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
+  /tr46@2.1.0:
+    resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
+    engines: {node: '>=8'}
+    dependencies:
+      punycode: 2.3.0
+    dev: false
+
   /tr46@4.1.1:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
@@ -7344,6 +7390,20 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
+
+  /typeson-registry@1.0.0-alpha.39:
+    resolution: {integrity: sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      base64-arraybuffer-es6: 0.7.0
+      typeson: 6.1.0
+      whatwg-url: 8.7.0
+    dev: false
+
+  /typeson@6.1.0:
+    resolution: {integrity: sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==}
+    engines: {node: '>=0.1.14'}
+    dev: false
 
   /ufo@1.3.1:
     resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
@@ -7502,7 +7562,7 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
 
-  /unstorage@1.9.0:
+  /unstorage@1.9.0(idb-keyval@6.2.1):
     resolution: {integrity: sha512-VpD8ZEYc/le8DZCrny3bnqKE4ZjioQxBRnWE+j5sGNvziPjeDlaS1NaFFHzl/kkXaO3r7UaF8MGQrs14+1B4pQ==}
     peerDependencies:
       '@azure/app-configuration': ^1.4.1
@@ -7544,6 +7604,7 @@ packages:
       chokidar: 3.5.3
       destr: 2.0.1
       h3: 1.8.2
+      idb-keyval: 6.2.1
       ioredis: 5.3.2
       listhen: 1.5.5
       lru-cache: 10.0.1
@@ -8123,6 +8184,15 @@ packages:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
 
+  /webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: false
+
+  /webidl-conversions@6.1.0:
+    resolution: {integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==}
+    engines: {node: '>=10.4'}
+    dev: false
+
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -8157,6 +8227,15 @@ packages:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
     dev: true
+
+  /whatwg-url@8.7.0:
+    resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
+    engines: {node: '>=10'}
+    dependencies:
+      lodash: 4.17.21
+      tr46: 2.1.0
+      webidl-conversions: 6.1.0
+    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
This will add some options for enabling some built-in mocks in nuxt-vitest. As for now I have added `intersectionObserver` (existing mock), and `indexedDB` (new mock).

I don't know if this is the best solution, but it is a start 😄

Ref. #287 