### PR TITLE
docs: update to vitest config with `.ts` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export default defineNuxtConfig({
 })
 ```
 
-3. Then create a `vitest.config.mjs` with the following content:
+3. Then create a `vitest.config.ts` with the following content:
 
 ```js
 import { defineVitestConfig } from 'nuxt-vitest/config'


### PR DESCRIPTION
# What?

Changed `vitest.config.mjs` to `vitest.config.ts` to be more in line with other Nuxt documentation consistency and reduce confusion.

# Why?

In the official [Nuxt: Getting Started Configuration](https://nuxt.com/docs/getting-started/configuration), it instructs the usage of a `vitest.config.ts` file. Furthermore, [Vitest: Configuration](https://vitest.dev/config/) also outlines the use of a `vitest.config.ts` file.